### PR TITLE
Change metadata type to Map<String, String>?

### DIFF
--- a/falu/src/main/java/io/falu/android/model/Evaluation.kt
+++ b/falu/src/main/java/io/falu/android/model/Evaluation.kt
@@ -63,7 +63,7 @@ data class EvaluationRequest(
     /**
      * Metadata
      */
-    var metadata: Any? = null
+    var metadata: Map<String, String>? = null
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/falu/src/main/java/io/falu/android/model/FaluModel.kt
+++ b/falu/src/main/java/io/falu/android/model/FaluModel.kt
@@ -16,5 +16,5 @@ open class FaluModel : Parcelable {
      * This can be useful for storing additional information about the object in a structured format.
      * The key can only contain alphanumeric, and ‘-’, ‘_’ characters, and the string has to start with a letter.
      */
-    var metadata: Any? = null
+    var metadata: Map<String, String>? = null
 }


### PR DESCRIPTION
Change metadata from `Any?` to `Map<String, String>?` which more accurately represents what the API expects.